### PR TITLE
Switch from SD library to SdFat library

### DIFF
--- a/test_code/tinylab_test_code/tinylab_test_code.ino
+++ b/test_code/tinylab_test_code/tinylab_test_code.ino
@@ -28,7 +28,7 @@
 #include <LiquidTWI2.h>
 #include <RotaryEncoder.h>
 #include <DS1307RTC.h>
-#include <SD.h>
+#include <SdFat.h>
 #include "LedControl.h"
 #include <extEEPROM.h>
 // Radio


### PR DESCRIPTION
SD library is extremely large.  SdFat library is much smaller and is fine for what this project does.  Making this change lowers project size from 99% of maximum upload to 86% of maximum.
