### PR TITLE
tinylab_test_code: Fix compilation with recent Arduino libraries

### DIFF
--- a/test_code/tinylab_test_code/tinylab_test_code.ino
+++ b/test_code/tinylab_test_code/tinylab_test_code.ino
@@ -25,6 +25,7 @@
 // libraries
 #include "Wire.h"
 #include <Time.h>
+#include <TimeLib.h>
 #include <LiquidTWI2.h>
 #include <RotaryEncoder.h>
 #include <DS1307RTC.h>

--- a/test_code/tinylab_test_code/tinylab_test_code.ino
+++ b/test_code/tinylab_test_code/tinylab_test_code.ino
@@ -444,7 +444,7 @@ void loop()
 				lcd.print("                ");
 
 		    	extEEPROM eep(kbits_256, 2, 64);
-		    	uint8_t eepStatus = eep.begin(twiClock400kHz);
+		    	uint8_t eepStatus = eep.begin(extEEPROM::twiClock400kHz);
 
 		    	if(eepStatus == 0){
 		    		lcd.setCursor(0, 1);


### PR DESCRIPTION
Tested with Arduino 1.8.2 (Windows 10) and the following libraries loaded by the Arduino Library Manager:

- DS1307RTC Version 1.4.0
- LedControl Version 1.0.6
- LiquidTWI2-master Version unknown (from https://github.com/lincomatic/LiquidTWI2)
- RF24 Version 1.3.0
- RotaryEncoder Version 1.1.0
- SdFat Version 1.0.3
- Time Version 1.5.0
- extEEPROM Version 3.3.5

Fix https://github.com/sixfab/tinylab/issues/6

Signed-off-by: Gianpaolo Macario <gmacario@gmail.com>